### PR TITLE
Fix warnings about using class for restricting protocols to classes.

### DIFF
--- a/EmptyStateKit/Classes/AssociationPolicy/AssociationPolicy.swift
+++ b/EmptyStateKit/Classes/AssociationPolicy/AssociationPolicy.swift
@@ -20,7 +20,7 @@ enum AssociationPolicy: UInt {
     }
 }
 
-protocol AssociatedObjects: class { }
+protocol AssociatedObjects: AnyObject { }
 
 // transparent wrappers
 extension AssociatedObjects {

--- a/EmptyStateKit/Classes/EmptyState.swift
+++ b/EmptyStateKit/Classes/EmptyState.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-public protocol EmptyStateDelegate: class {
+public protocol EmptyStateDelegate: AnyObject {
     func emptyState(emptyState: EmptyState, didPressButton button: UIButton)
 }
 
-public protocol EmptyStateDataSource: class {
+public protocol EmptyStateDataSource: AnyObject {
     func imageForState(_ state: CustomState, inEmptyState emptyState: EmptyState) -> UIImage?
     func titleForState(_ state: CustomState, inEmptyState emptyState: EmptyState) -> String?
     func descriptionForState(_ state: CustomState, inEmptyState emptyState: EmptyState) -> String?

--- a/EmptyStateKit/Classes/NibView.swift
+++ b/EmptyStateKit/Classes/NibView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol NibViewProtocol: class {
+protocol NibViewProtocol: AnyObject {
     func commonInit()
 }
 

--- a/EmptyStateKit/Classes/Protocols/NibLoadable.swift
+++ b/EmptyStateKit/Classes/Protocols/NibLoadable.swift
@@ -16,7 +16,7 @@ import UIKit
  *
  * to be able to instantiate them from the NIB in a type-safe manner
  */
-protocol NibLoadable: class {
+protocol NibLoadable: AnyObject {
     /// The nib file to use to load a new instance of the View designed in a XIB
     static var nib: UINib { get }
 }


### PR DESCRIPTION
Using `class` to restrict protocols to just classes is deprecated. Instead we need to use AnyObject. This PR will get rid of 5 warnings:

```
Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
```

@alberdev 